### PR TITLE
Optional value for users password

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "users" {
 
   type = list(object({
     name     = string
-    password = string
+    password = optional(string, null)
     quota    = optional(list(object({
       interval_duration = string
       queries           = optional(number, null)


### PR DESCRIPTION
Hello! Values for password looks like should be an optional (with two types - string or null). If you don't, you should to explicitly set a password in your manifest.